### PR TITLE
Added PsalmTypeIgnore attribute, marking forms that cannot be processed

### DIFF
--- a/src/Attribute/PsalmTypeIgnore.php
+++ b/src/Attribute/PsalmTypeIgnore.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kynx\Laminas\FormShape\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class PsalmTypeIgnore
+{
+}

--- a/src/Locator/RecursiveReflectionIterator.php
+++ b/src/Locator/RecursiveReflectionIterator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kynx\Laminas\FormShape\Locator;
 
+use Kynx\Laminas\FormShape\Attribute\PsalmTypeIgnore;
 use RecursiveIterator;
 use ReflectionClass;
 use SplFileInfo;
@@ -31,15 +32,20 @@ final class RecursiveReflectionIterator implements RecursiveIterator
 
     public function current(): ?ReflectionClass
     {
-        $current = $this->iterator->current();
+        $current    = $this->iterator->current();
+        $reflection = null;
         if ($current instanceof SplFileInfo) {
-            return $this->reflectionProvider->getReflection($current->getPathname());
+            $reflection = $this->reflectionProvider->getReflection($current->getPathname());
         }
         if (is_string($current)) {
-            return $this->reflectionProvider->getReflection($current);
+            $reflection = $this->reflectionProvider->getReflection($current);
         }
 
-        return null;
+        if ($reflection !== null && $reflection->getAttributes(PsalmTypeIgnore::class) !== []) {
+            return null;
+        }
+
+        return $reflection;
     }
 
     public function next(): void

--- a/test/Locator/Asset/IgnoredForm.php
+++ b/test/Locator/Asset/IgnoredForm.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KynxTest\Laminas\FormShape\Locator\Asset;
+
+use Kynx\Laminas\FormShape\Attribute\PsalmTypeIgnore;
+use Laminas\Form\Form;
+
+#[PsalmTypeIgnore]
+final class IgnoredForm extends Form
+{
+}


### PR DESCRIPTION
Example of form that will not be processed:

```php

use Kynx\Laminas\FormShape\Attribute\PsalmTypeIgnore;

#[PsalmTypeIgnore]
class MyForm extends Form
{
    // stuff...
}
```